### PR TITLE
Implement basic user post CRUD functionality

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
           command: "export PATH=\"$PATH:/root/.dotnet/tools\" && dotnet ef database update --project Api/Api.csproj"
       - run:
           name: "Run tests"
+          requires: "Apply database migrations"
           working_directory: ~/project/backend
           command: "dotnet test TVBackend.sln --configuration Release -tl:off"
 

--- a/backend/Api/Api.csproj
+++ b/backend/Api/Api.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -16,6 +17,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.6.9" />
   </ItemGroup>
 
 </Project>

--- a/backend/Api/Controllers/PostsController.cs
+++ b/backend/Api/Controllers/PostsController.cs
@@ -1,0 +1,95 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using System.Security.Claims;
+using Api.Models;
+using Api.Services;
+using System.Numerics;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Api.ServiceUtils;
+
+namespace Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")] // base route: /api/example
+    public class PostsController : ControllerBase
+    {
+        private readonly PostsService _postsService;
+        public PostsController(PostsService postsService)
+        {
+            _postsService = postsService;
+        }
+
+
+        [HttpGet]
+        public async Task<IActionResult> GetPosts(
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 10,
+            [FromQuery] string sortBy = "createdat",
+            [FromQuery] string sortOrder = "desc",
+            [FromQuery] int? userId = null,
+            [FromQuery] string? search = null
+        )
+        {
+            var (returnCode,posts) = await _postsService.GetPosts(
+                page, pageSize,
+                sortBy, sortOrder,
+                userId,
+                search
+            );
+            var result = ServiceHelper.HandleReturnCode(returnCode);
+            if (result is not OkResult) { return result; }
+            return Ok(posts);
+        }
+
+        [HttpPut("create")]
+        [Authorize]
+        public async Task<IActionResult> CreatePost([FromBody] CreatePostDTO post)
+        {
+            var userIdStr = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (userIdStr == null)
+            {
+                return Unauthorized();
+            }
+            int userId = int.Parse(userIdStr);
+
+            var (returnCode,createdPost) = await _postsService.CreatePost(userId, post.Content);
+            var result = ServiceHelper.HandleReturnCode(returnCode);
+            if (result is not OkResult) { return result; }
+            return Ok(createdPost);
+        }
+
+        [HttpPost("delete")]
+        [Authorize]
+        public async Task<IActionResult> DeletePost([FromBody] DeletePostDTO post)
+        {
+            var userIdStr = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (userIdStr == null)
+            {
+                return Unauthorized();
+            }
+            int userId = int.Parse(userIdStr);
+
+            var (returnCode, deletedPost) = await _postsService.DeletePost(userId, post);
+            var result = ServiceHelper.HandleReturnCode(returnCode);
+            if (result is not OkResult) { return result; }
+            return Ok(deletedPost);
+        }
+
+        [HttpPost("update")]
+        [Authorize]
+        public async Task<IActionResult> UpdatePost([FromBody] UpdatePostDTO post)
+        {
+            var userIdStr = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (userIdStr == null)
+            {
+                return Unauthorized();
+            }
+            int userId = int.Parse(userIdStr);
+
+            var (returnCode, updatedPost) = await _postsService.UpdatePost(userId, post);
+            var result = ServiceHelper.HandleReturnCode(returnCode);
+            if (result is not OkResult) { return result; }
+            return Ok(updatedPost);
+        }
+    }
+}

--- a/backend/Api/Models/DatabaseModels.cs
+++ b/backend/Api/Models/DatabaseModels.cs
@@ -40,7 +40,7 @@ namespace Api.Models
     }
     public class Post
     {
-        public required int Id { get; set; }
+        public int Id { get; set; }
         public required int UserId { get; set; }
         public required string Content { get; set; }
         public DateTime CreatedAt { get; set; }
@@ -48,8 +48,8 @@ namespace Api.Models
         public bool IsOfficial { get; set; }
         public bool IsDeleted { get; set; }
 
-        public required User Author { get; set; }
-        public required List<PostReaction> Reactions { get; set; }
+        public User? Author { get; set; }
+        public List<PostReaction> Reactions { get; set; } = new();
     }
     public class PostReaction
     {
@@ -73,7 +73,7 @@ namespace Api.Models
         public int SignatureCount { get; set; }
         public PetitionStatus Status { get; set; }
 
-        public required List<PetitionSignature> Signatures { get; set; } = new();  
+        public List<PetitionSignature> Signatures { get; set; } = new();  
     }
     public class PetitionSignature
     {

--- a/backend/Api/Models/JwtSettings.cs
+++ b/backend/Api/Models/JwtSettings.cs
@@ -2,7 +2,7 @@ namespace Api.Models
 {
     public class JwtSettings
     {
-        public string SecretKey { get; set; } = "";
+        public string Key { get; set; } = "";
         public string Issuer { get; set; } = "";
         public string Audience { get; set; } = "";
         public int ExpiryMinutes { get; set; } = 60;

--- a/backend/Api/Models/PostDTO.cs
+++ b/backend/Api/Models/PostDTO.cs
@@ -1,0 +1,34 @@
+namespace Api.Models
+{
+    public class PostQueryDTO
+    {
+        public required int TotalItems { get; set; }
+        public required int Page { get; set; }
+        public required int PageSize { get; set; }
+        public required int TotalPages { get; set; }
+        public required List<PostDTO> Posts { get; set; }
+    }
+    public class PostDTO
+    {
+        public int Id { get; set; }
+        public required string Content { get; set; }
+        public required DateTime CreatedAt { get; set; }
+        public required DateTime? UpdatedAt { get; set; }
+        public required string Author { get; set; }
+        public required List<PostReaction> Reactions { get; set; }
+    }
+    public class CreatePostDTO
+    {
+        public int Id { get; set; }
+        public required string Content { get; set; }
+    }
+    public class DeletePostDTO
+    {
+        public required int Id { get; set; }
+    }
+    public class UpdatePostDTO
+    {
+        public required int Id { get; set; }
+        public required string NewContent { get; set; }
+    }
+}

--- a/backend/Api/Program.cs
+++ b/backend/Api/Program.cs
@@ -4,23 +4,53 @@ using Api.Services;
 using Api.Controllers;
 using Api.Models;
 using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
-builder.Services.AddScoped<UserService>();
+
+
+// Configuring JWT
 builder.Services.Configure<JwtSettings>(
     builder.Configuration.GetSection("JwtSettings") // reads from appsettings.json "JwtSettings" section
 );
+var jwtSettings = builder.Configuration
+    .GetSection("JwtSettings")
+    .Get<JwtSettings>();
+
+var key = Encoding.ASCII.GetBytes(jwtSettings!.Key);
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+})
+.AddJwtBearer(options =>
+{
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = true, // set to true if you have an issuer
+        ValidIssuer = "TownVoice",
+        ValidateAudience = true, // set to true if you have an audience
+        ValidAudience = "TownVoice",
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(key),
+        ValidateLifetime = true
+    };
+});
+
+builder.Services.AddScoped<UserService>();
+builder.Services.AddScoped<PostsService>();
 builder.Services.AddScoped(sp =>
     sp.GetRequiredService<IOptions<JwtSettings>>().Value);
 builder.Services.AddScoped<JwtService>();
-
 builder.Services.AddControllers();
 builder.Services.AddDbContext<TVDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -36,3 +66,5 @@ app.UseAuthorization();
 app.MapControllers();
 
 app.Run();
+
+public partial class Program { }  // Allows for E2E tests using the actual server

--- a/backend/Api/Services/JwtService.cs
+++ b/backend/Api/Services/JwtService.cs
@@ -17,7 +17,7 @@ namespace Api.Controllers
 
         public string GenerateJwt(User user)
         {
-            var key = Encoding.ASCII.GetBytes(_config.SecretKey);
+            var key = Encoding.ASCII.GetBytes(_config.Key);
             var tokenDescriptor = new SecurityTokenDescriptor
             {
                 Subject = new ClaimsIdentity(

--- a/backend/Api/Services/PostsService.cs
+++ b/backend/Api/Services/PostsService.cs
@@ -1,0 +1,128 @@
+using Api.Data;
+using Api.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration.UserSecrets;
+using System.ComponentModel;
+using System.Linq.Dynamic.Core;
+using System.Reflection;
+using Api.ServiceUtils;
+
+/*
+TODO:
+ESSENTIALS: GetAll (maybe not ALL) posts, GetAPost, GetPostsByUser, CreatePost, UpdatePost, DeletePost 
+EXTRA: ReactToPost, GetPostReactions, GetRepliesToAPost, CreateReplyToAPost, UpdateReplyToAPost, DeleteReplyToAPost
+*/
+namespace Api.Services
+{
+    public class PostsService
+    {
+        private readonly TVDbContext _context;
+
+        public PostsService(TVDbContext context)
+        {
+            _context = context;
+        }
+        public async Task<(ServiceReturnCode, PostQueryDTO?)> GetPosts(
+            int page,
+            int pageSize,
+            string sortBy,
+            string sortOrder,
+            int? userId,
+            string? search
+        )
+        {
+            if (page <= 0 || pageSize <= 0) { return (ServiceReturnCode.InvalidInput, null); }
+            var sortProperty = typeof(Post).GetProperty(sortBy, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance); 
+            if (sortProperty == null) { return (ServiceReturnCode.InvalidInput, null); }
+
+            var query = _context.Posts.AsQueryable();
+            if (userId.HasValue)
+            {
+                query = query.Where(p => p.UserId == userId);
+            }
+            if (search != null)
+            {
+                query = query.Where(p => p.Content.Contains(search));
+            }
+            query = sortOrder.ToLower() == "asc"
+                ? query.OrderBy(sortBy)
+                : query.OrderBy(sortBy + " descending");
+            query = query
+                .Where(p => !p.IsDeleted)
+                .Where(p => !p.IsOfficial);
+            var totalItems = await query.CountAsync();
+            var posts = await query
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .Include(p => p.Author)
+                .ToListAsync();
+            return (ServiceReturnCode.Success, new PostQueryDTO
+            {
+                TotalItems = totalItems,
+                Page = page,
+                PageSize = pageSize,
+                TotalPages = (int)Math.Ceiling(totalItems / (double)pageSize),
+                Posts = posts.Select(p => new PostDTO
+                {
+                    Id = p.Id,
+                    Content = p.Content,
+                    CreatedAt = p.CreatedAt,
+                    UpdatedAt = p.UpdatedAt,
+                    Author = p!.Author!.Username,
+                    Reactions = p.Reactions
+                }).ToList()
+            });
+        }
+        public async Task<(ServiceReturnCode, CreatePostDTO?)> CreatePost(int userId, string content)
+        {
+            if (String.IsNullOrEmpty(content)) { return (ServiceReturnCode.InvalidInput,null); }
+            var post = new Post
+            {
+                UserId = userId,
+                Content = content,
+                CreatedAt = DateTime.UtcNow,
+            };
+            var createdPost = await _context.AddAsync(post);
+            if (createdPost == null) { return (ServiceReturnCode.InternalError,null); }
+            await _context.SaveChangesAsync();
+            return (ServiceReturnCode.Success,new CreatePostDTO
+            {
+                Id = post.Id,
+                Content = post.Content,
+            });
+        }
+        public async Task<(ServiceReturnCode, DeletePostDTO?)> DeletePost(int userId, DeletePostDTO post)
+        {
+            var postToDelete = await _context
+                .Posts
+                .FirstOrDefaultAsync(p => p.Id == post.Id);
+            if (postToDelete == null) { return (ServiceReturnCode.NotFound, null); }
+            if (postToDelete.UserId != userId) { return (ServiceReturnCode.Unauthorized, null); }
+            if (postToDelete.IsDeleted) { return (ServiceReturnCode.NotFound, null); }
+            postToDelete.IsDeleted = true;
+            await _context.SaveChangesAsync();
+            return (ServiceReturnCode.Success, new DeletePostDTO
+            {
+                Id = postToDelete.Id
+            });
+        }
+
+        public async Task<(ServiceReturnCode, UpdatePostDTO?)> UpdatePost(int userId, UpdatePostDTO post)
+        {
+            var postToUpdate = await _context
+                .Posts
+                .FirstOrDefaultAsync(p => p.Id == post.Id);
+            if (postToUpdate == null) { return (ServiceReturnCode.NotFound, null); }
+            if (postToUpdate.UserId != userId) { return (ServiceReturnCode.Unauthorized, null); }
+            if (postToUpdate.IsDeleted) { return (ServiceReturnCode.NotFound, null); }
+            postToUpdate.UpdatedAt = DateTime.UtcNow;
+            postToUpdate.Content = post.NewContent;
+            await _context.SaveChangesAsync();
+            return (ServiceReturnCode.Success, new UpdatePostDTO
+            {
+                Id = postToUpdate.Id,
+                NewContent = postToUpdate.Content
+            });
+        }
+    }
+}

--- a/backend/Api/Utils/ServiceUtils.cs
+++ b/backend/Api/Utils/ServiceUtils.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Api.ServiceUtils
+{
+    public enum ServiceReturnCode
+    {
+        Success,
+        NotFound,
+        Unauthorized,
+        InvalidInput,
+        Conflict,
+        InternalError
+    }
+    public static class ServiceHelper
+    {
+        public static IActionResult HandleReturnCode(ServiceReturnCode code)
+        {
+            return code switch
+            {
+                ServiceReturnCode.NotFound => new NotFoundResult(),
+                ServiceReturnCode.Unauthorized => new UnauthorizedResult(),
+                ServiceReturnCode.InvalidInput => new BadRequestObjectResult(new { err="Invalid input" }),
+                ServiceReturnCode.Conflict => new ConflictResult(),
+                ServiceReturnCode.InternalError => new StatusCodeResult(420), // This shouldn't actually happen, its a fake code
+                ServiceReturnCode.Success => new OkResult(),
+                _ => throw new NotImplementedException()
+            };
+        }
+    }
+}

--- a/backend/Api/appsettings.json
+++ b/backend/Api/appsettings.json
@@ -10,9 +10,10 @@
   },
   "AllowedHosts": "*",
   "JwtSettings": {
-    "SecretKey": "SECRET_KEY_HERE", 
+    "Key": "e415e7b09b4460d57111444049470d1d1dee491e23a1565a290b60d02673758e2774413b17b0034c604ec0d7aae0f3f5197d8436b6899d637b4ad445c7f0bff3",  
     "Issuer": "TownVoice",
-    "Audience": "TownVoicers",
+    "Audience": "TownVoice",
     "ExpiryMinutes": 60
-  }
+  },
+  "Note": "The JWT Key above is FAKE. Do NOT commit the real key to the repo. I will know if you do."
 }

--- a/backend/Docs/API.md
+++ b/backend/Docs/API.md
@@ -6,7 +6,7 @@ Base URL: https://PENDINGDOMAINNAME.com/api
 ---
 
 ## User Authentication
-### GET `/{id}`
+### GET `/users/{id}`
 **Description:** Get a user by their ID
 
 **Responses:**
@@ -22,7 +22,7 @@ Base URL: https://PENDINGDOMAINNAME.com/api
 ```
 404 Not Found
 
-### POST `/register`
+### POST `/users/register`
 **Description:** Register a new user account
 
 **Request Body (JSON):**
@@ -53,7 +53,7 @@ will be set to null if left blank.
 400 Bad Request
 409 Conflict
 
-### Post `/login`
+### Post `/users/login`
 **Description:** Login using an existing user account and password
 
 **Request Body (JSON):**
@@ -74,3 +74,111 @@ will be set to null if left blank.
 ```
 400 Bad Request
 401 Unauthorized
+
+## User Posts
+### GET `/posts/`
+**Description:** Get a selection of posts based on a query, optionally sorted
+
+**Parameters:**
+|Name     |Type  |Required|Example    |Valid Values                                   |Default    |Description                                                                    |
+|:--------|:-----|:-------|:----------|:----------------------------------------------|:----------|:------------------------------------------------------------------------------|
+|page     |int   |true    |1          |page > 0                                       |1          |Group posts into groups of pageSize size and return the group with index `page`|
+|pageSize |int   |true    |10         |pageSize > 0                                   |10         |Determine the size of group for grouping posts into pages                      |
+|sortBy   |string|true    |"createdat"|"id","userid","content","createdat","updatedat"|"createdat"|Parameter to sort queried posts by                                             |
+|sortOrder|string|true    |"desc"     |"asc","desc"                                   |"desc"     |Order to sort posts in                                                         |
+|userId   |int   |false   |1          |userId >= 0                                    |null       |Optional parameter to limit posts to posts made by user with id `userid`       |
+|search   |string|false   |"findthis" |any string                                     |null       |Optional parameter to limit posts to posts containing the string `search`      |
+
+**Responses:**
+200 Ok
+```json
+{
+    "totalItems": 1,
+    "page": 1,
+    "pageSize": 10,
+    "totalPages": 1
+    "posts": [
+        {
+            "id": 1
+            "userId": 2,
+            "content": "Example post",
+            "createdAt": "2025-10-29T05:21:58.121288Z",
+            "updatedAt": null,
+            "reactions": [] 
+        }
+    ]
+}
+```
+400 Bad Request
+
+### PUT `/posts/create`
+**Description:** Create a post, requires a valid JWT
+
+**Request Body (JSON):**
+```json
+{
+    "id": 1
+    "userId": 1,
+    "content": "This is an example post!"
+    "createdAt": "2025-10-30T04:11:38.506352Z",
+    "updatedAt": null,
+    "isOfficial": false,
+    "isDeleted": false,
+    "author": null,
+    "reactions": []
+}
+```
+
+**Responses:**
+200 Ok
+```json
+{
+    "id" = 1,
+    "content" = "This is an example post!"
+}
+```
+400 BadRequest
+401 Unauthorized
+409 Conflict
+
+### POST `/posts/delete`
+**Description:** Delete a post, requires a valid JWT and a valid target
+
+**Request Body (JSON):**
+```json
+{
+    "id" = 1
+}
+```
+
+**Responses:**
+200 Ok
+```json
+{
+    "id" = 1
+}
+```
+401 Unauthorized
+404 Not Found
+
+### POST `/posts/update`
+**Description:** Update the contents of a post, requires a valid JWT and a valid target
+
+**Request Body (JSON):**
+```json
+{
+    "id" = 1,
+    "newcontent" = "This an updated post."
+}
+```
+
+**Responses:**
+200 Ok
+```json
+{
+    "id" = 1,
+    "newcontent" = "This an updated post."
+}
+```
+401 Unauthorized
+404 Not Found

--- a/backend/Tests/PostTests.cs
+++ b/backend/Tests/PostTests.cs
@@ -1,0 +1,170 @@
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using Api.Services;
+using Api.Models;
+using Api.Controllers;
+using Api.Data;
+using System.Net.Http;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Net;
+
+public class PostApiTests : IClassFixture<WebApplicationFactory<Program>>, IDisposable
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    public PostApiTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureLogging(logging =>
+            {
+                logging.ClearProviders();
+            });
+        });
+    }
+
+    private void ClearDatabase(TVDbContext dbContext)
+    {
+        dbContext.Users.RemoveRange(dbContext.Users);
+        dbContext.Posts.RemoveRange(dbContext.Posts);
+        dbContext.SaveChanges();
+    }
+
+    [Fact]
+    public async Task CreateUpdateDeletePostWithValidJWT_EndToEnd()
+    {
+        HttpClient client = _factory.CreateClient();
+        using var scope = _factory.Services.CreateScope();
+        TVDbContext dbContext = scope.ServiceProvider.GetRequiredService<TVDbContext>();
+        ClearDatabase(dbContext);
+        // Arrange
+        // Create user
+        string username = "john";
+        string name = "John Dingle";
+        string email = "test@tester.com";
+        string password = "P@ssw0rd!";
+        var createUserRequest = new CreateUserRequest { Username = username, Name = name, Email = email, Password = password };
+        var createUserResponse = await client.PostAsJsonAsync("/api/users/register", createUserRequest);
+        createUserResponse.EnsureSuccessStatusCode();
+
+        // Login and store JWT
+        var loginRequest = new UserLoginRequest { Username = username, Password = password };
+        var loginResponse = await client.PostAsJsonAsync("/api/users/login", loginRequest);
+        loginResponse.EnsureSuccessStatusCode();
+        var loginResult = await loginResponse.Content.ReadFromJsonAsync<UserLoginResponse>();
+        string jwt = loginResult!.Token;
+        client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwt);
+
+        // Test CRUD endpoints
+        var postRequest = new CreatePostDTO
+        {
+            Content = "Hello world!"
+        };
+        var makePostResponse = await client.PutAsJsonAsync("/api/posts/create", postRequest);
+        makePostResponse.EnsureSuccessStatusCode();
+        var makePostResult = await makePostResponse.Content.ReadFromJsonAsync<CreatePostDTO>();
+        var postId = makePostResult!.Id;
+
+        var updatePostRequest = new UpdatePostDTO
+        {
+            Id = postId,
+            NewContent = "Goodbye world!"
+        };
+        var updatePostResponse = await client.PostAsJsonAsync("/api/posts/update", updatePostRequest);
+        updatePostResponse.EnsureSuccessStatusCode();
+
+        var deletePostRequest = new DeletePostDTO
+        {
+            Id = postId
+        };
+        var deletePostResponse = await client.PostAsJsonAsync("/api/posts/delete", deletePostRequest);
+        deletePostResponse.EnsureSuccessStatusCode();
+
+        var post = await dbContext.Posts.FirstOrDefaultAsync(p => p.Id == postId);
+        Assert.Equal("Goodbye world!", post!.Content);
+        Assert.NotNull(post!.UpdatedAt);
+        Assert.True(post!.IsDeleted);
+    }
+    [Fact]
+    public async Task CreatePostWithoutJWT_EndToEnd()
+    {
+        HttpClient client = _factory.CreateClient();
+        using var scope = _factory.Services.CreateScope();
+        TVDbContext dbContext = scope.ServiceProvider.GetRequiredService<TVDbContext>();
+        ClearDatabase(dbContext);
+
+        var postRequest = new CreatePostDTO
+        {
+            Content = "Hello world!"
+        };
+        var makePostResponse = await client.PutAsJsonAsync("/api/posts/create", postRequest);
+        Assert.Equal(HttpStatusCode.Unauthorized, makePostResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteOrEditAnotherUserPost_EndToEnd()
+    {
+
+        HttpClient client = _factory.CreateClient();
+        using var scope = _factory.Services.CreateScope();
+        TVDbContext dbContext = scope.ServiceProvider.GetRequiredService<TVDbContext>();
+        UserService userService = new UserService(dbContext);
+        PostsService postsService = new PostsService(dbContext);
+        ClearDatabase(dbContext);
+
+        // Create user
+        string username = "john";
+        string name = "John Dingle";
+        string email = "test@tester.com";
+        string password = "P@ssw0rd!";
+        var createUserRequest = new CreateUserRequest { Username = username, Name = name, Email = email, Password = password };
+        var createUserResponse = await client.PostAsJsonAsync("/api/users/register", createUserRequest);
+        createUserResponse.EnsureSuccessStatusCode();
+
+        // Login and store JWT
+        var loginRequest = new UserLoginRequest { Username = username, Password = password };
+        var loginResponse = await client.PostAsJsonAsync("/api/users/login", loginRequest);
+        loginResponse.EnsureSuccessStatusCode();
+        var loginResult = await loginResponse.Content.ReadFromJsonAsync<UserLoginResponse>();
+        string jwt = loginResult!.Token;
+        client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwt);
+
+        // Create a post from another user
+        var newUser = await userService.RegisterUserAsync(new CreateUserRequest
+        {
+            Username = "tester2",
+            Name = "tester2",
+            Email = "tester@test.com",
+            Password = "P@ssw0rd!",
+        });
+        var (_, newPost) = await postsService.CreatePost(newUser!.Id, "Not Hello World!");
+        int postId = newPost!.Id;
+
+        // Attempt to edit and delete
+        var updatePostRequest = new UpdatePostDTO
+        {
+            Id = postId,
+            NewContent = "Goodbye world!"
+        };
+        var updatePostResponse = await client.PostAsJsonAsync("/api/posts/update", updatePostRequest);
+        Assert.Equal(HttpStatusCode.Unauthorized, updatePostResponse.StatusCode);
+
+        var deletePostRequest = new DeletePostDTO
+        {
+            Id = postId
+        };
+        var deletePostResponse = await client.PostAsJsonAsync("/api/posts/delete", deletePostRequest);
+        Assert.Equal(HttpStatusCode.Unauthorized, deletePostResponse.StatusCode);
+
+    }
+    public void Dispose()
+    {
+        using var scope = _factory.Services.CreateScope();
+        TVDbContext dbContext = scope.ServiceProvider.GetRequiredService<TVDbContext>();
+        ClearDatabase(dbContext);
+    }
+}

--- a/backend/Tests/UserTests.cs
+++ b/backend/Tests/UserTests.cs
@@ -4,11 +4,7 @@ using Api.Services;
 using Api.Models;
 using Api.Controllers;
 using Api.Data;
-using Api.Password;
 
-using Microsoft.Extensions.Options;
-using System.IdentityModel.Tokens.Jwt;
-using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 public class UserApiTests
 {
@@ -20,7 +16,7 @@ public class UserApiTests
         );
         var userService = new UserService(context);
         var jwtService = new JwtService(new JwtSettings {
-            SecretKey = "djsfadk!%adjs12!@$#89@#$120d71289;%@!327akl;3127%!%kl;%!21", // hows that for random
+            Key = "djsfadk!%adjs12!@$#89@#$120d71289;%@!327akl;3127%!%kl;%!21", // hows that for random
             Issuer = "TownVoice",
             Audience = "TownVoicers",
             ExpiryMinutes = 60


### PR DESCRIPTION
This commit adds basic functionality for user posts. Currently, a user receives a JWT on successful sign-in. With this JWT, posts can be made from an endpoint, as well as updated or deleted. Posts can be queried with a variety of parameters without the need for a JWT. Documentation for this is in `Docs/API.md`. Additionally, there are small tweaks to some classnames, members, etc. Some of these are actually breaking changes, but nobody has used the backend APIs yet. Woo!