### PR TITLE
Update user post API routes to better follow REST conventions

### DIFF
--- a/backend/Api/Controllers/PostsController.cs
+++ b/backend/Api/Controllers/PostsController.cs
@@ -42,7 +42,7 @@ namespace Api.Controllers
             return Ok(posts);
         }
 
-        [HttpPut("create")]
+        [HttpPut]
         [Authorize]
         public async Task<IActionResult> CreatePost([FromBody] CreatePostDTO post)
         {
@@ -59,7 +59,7 @@ namespace Api.Controllers
             return Ok(createdPost);
         }
 
-        [HttpPost("{postId}/delete")]
+        [HttpDelete("{postId}")]
         [Authorize]
         public async Task<IActionResult> DeletePost(int postId)
         {
@@ -76,7 +76,7 @@ namespace Api.Controllers
             return Ok(deletedPost);
         }
 
-        [HttpPost("{postId}/update")]
+        [HttpPost("{postId}")]
         [Authorize]
         public async Task<IActionResult> UpdatePost(int postId, [FromBody] UpdatePostDTO post)
         {

--- a/backend/Docs/API.md
+++ b/backend/Docs/API.md
@@ -76,7 +76,7 @@ will be set to null if left blank.
 401 Unauthorized
 
 ## User Posts
-### GET `/posts/`
+### GET `/posts`
 **Description:** Get a selection of top level posts based on a query, optionally sorted.
 
 **Parameters:**
@@ -111,21 +111,13 @@ will be set to null if left blank.
 ```
 400 Bad Request
 
-### PUT `/posts/create`
+### PUT `/posts`
 **Description:** Create a post, requires a valid JWT.
 
 **Request Body (JSON):**
 ```json
 {
-    "id": 1
-    "userId": 1,
     "content": "This is an example post!"
-    "createdAt": "2025-10-30T04:11:38.506352Z",
-    "updatedAt": null,
-    "isOfficial": false,
-    "isDeleted": false,
-    "author": null,
-    "reactions": []
 }
 ```
 
@@ -141,7 +133,7 @@ will be set to null if left blank.
 401 Unauthorized
 409 Conflict
 
-### POST `/posts/{postId}/delete`
+### DELETE `/posts/{postId}`
 **Description:** Delete a post, requires a valid JWT and a valid target. If a post is a "top-level" post, ie it has no parent, then all child posts are recursively deleted in the entire hierarchy.
 
 
@@ -155,7 +147,7 @@ will be set to null if left blank.
 401 Unauthorized
 404 Not Found
 
-### POST `/posts/{postId}/update`
+### POST `/posts/{postId}`
 **Description:** Update the contents of a post, requires a valid JWT and a valid target.
 
 **Request Body (JSON):**
@@ -176,7 +168,7 @@ will be set to null if left blank.
 401 Unauthorized
 404 Not Found
 
-### POST `/posts/{postId}/replies`
+### PUT `/posts/{postId}/replies`
 **Description:** Create a reply to an existing post or reply, requires a valid JWT and a valid target.
 
 **Request Body (JSON):**
@@ -234,7 +226,7 @@ will be set to null if left blank.
 ```
 404 Not Found
 
-### POST `/posts/{postId}/reactions`
+### PUT `/posts/{postId}/reactions`
 **Description:** Create a reaction to a specified post, requires a valid target and a valid JWT. 
 
 **Request Body (JSON):**

--- a/backend/Tests/PostTests.cs
+++ b/backend/Tests/PostTests.cs
@@ -66,7 +66,7 @@ public class PostApiTests : IClassFixture<WebApplicationFactory<Program>>, IDisp
         {
             Content = "Hello world!"
         };
-        var makePostResponse = await client.PutAsJsonAsync("/api/posts/create", postRequest);
+        var makePostResponse = await client.PutAsJsonAsync("/api/posts", postRequest);
         makePostResponse.EnsureSuccessStatusCode();
         var makePostResult = await makePostResponse.Content.ReadFromJsonAsync<CreatePostDTO>();
         var postId = makePostResult!.Id;
@@ -75,10 +75,10 @@ public class PostApiTests : IClassFixture<WebApplicationFactory<Program>>, IDisp
         {
             NewContent = "Goodbye world!"
         };
-        var updatePostResponse = await client.PostAsJsonAsync($"/api/posts/{postId}/update", updatePostRequest);
+        var updatePostResponse = await client.PostAsJsonAsync($"/api/posts/{postId}", updatePostRequest);
         updatePostResponse.EnsureSuccessStatusCode();
 
-        var deletePostResponse = await client.PostAsJsonAsync($"/api/posts/{postId}/delete","");
+        var deletePostResponse = await client.DeleteAsync($"/api/posts/{postId}");
         deletePostResponse.EnsureSuccessStatusCode();
 
         var post = await dbContext.Posts.FirstOrDefaultAsync(p => p.Id == postId);
@@ -98,7 +98,7 @@ public class PostApiTests : IClassFixture<WebApplicationFactory<Program>>, IDisp
         {
             Content = "Hello world!"
         };
-        var makePostResponse = await client.PutAsJsonAsync("/api/posts/create", postRequest);
+        var makePostResponse = await client.PutAsJsonAsync("/api/posts", postRequest);
         Assert.Equal(HttpStatusCode.Unauthorized, makePostResponse.StatusCode);
     }
 
@@ -146,10 +146,10 @@ public class PostApiTests : IClassFixture<WebApplicationFactory<Program>>, IDisp
         {
             NewContent = "Goodbye world!"
         };
-        var updatePostResponse = await client.PostAsJsonAsync($"/api/posts/{postId}/update", updatePostRequest);
+        var updatePostResponse = await client.PostAsJsonAsync($"/api/posts/{postId}", updatePostRequest);
         Assert.Equal(HttpStatusCode.Unauthorized, updatePostResponse.StatusCode);
 
-        var deletePostResponse = await client.PostAsJsonAsync($"/api/posts/{postId}/delete","");
+        var deletePostResponse = await client.DeleteAsync($"/api/posts/{postId}");
         Assert.Equal(HttpStatusCode.Unauthorized, deletePostResponse.StatusCode);
 
     }
@@ -183,7 +183,7 @@ public class PostApiTests : IClassFixture<WebApplicationFactory<Program>>, IDisp
         {
             Content = "Hello world!"
         };
-        var makePostResponse = await client.PutAsJsonAsync("/api/posts/create", postRequest);
+        var makePostResponse = await client.PutAsJsonAsync("/api/posts", postRequest);
         makePostResponse.EnsureSuccessStatusCode();
         var makePostResult = await makePostResponse.Content.ReadFromJsonAsync<CreatePostDTO>();
         var postId = makePostResult!.Id;
@@ -199,10 +199,10 @@ public class PostApiTests : IClassFixture<WebApplicationFactory<Program>>, IDisp
         {
             NewContent = "Goodbye world!"
         };
-        var updateReplyResponse = await client.PostAsJsonAsync($"/api/posts/{replyId}/update", updateReplyRequest);
+        var updateReplyResponse = await client.PostAsJsonAsync($"/api/posts/{replyId}", updateReplyRequest);
         updateReplyResponse.EnsureSuccessStatusCode();
 
-        var deleteReplyResponse = await client.PostAsJsonAsync($"/api/posts/{replyId}/delete", "");
+        var deleteReplyResponse = await client.DeleteAsync($"/api/posts/{replyId}");
         deleteReplyResponse.EnsureSuccessStatusCode();
 
         var post = await dbContext.Posts.FirstOrDefaultAsync(p => p.Id == replyId);
@@ -270,7 +270,7 @@ public class PostApiTests : IClassFixture<WebApplicationFactory<Program>>, IDisp
         {
             Content = "Post"
         };
-        var postResponse = await client.PutAsJsonAsync("/api/posts/create", postRequest);
+        var postResponse = await client.PutAsJsonAsync("/api/posts", postRequest);
         postResponse.EnsureSuccessStatusCode();
         var postResult = await postResponse.Content.ReadFromJsonAsync<CreatePostDTO>();
         var reply1Response = await client.PutAsJsonAsync($"api/posts/{postResult!.Id}/replies", postRequest);
@@ -281,7 +281,7 @@ public class PostApiTests : IClassFixture<WebApplicationFactory<Program>>, IDisp
         var reply2Result = await reply2Response.Content.ReadFromJsonAsync<CreatePostDTO>();
 
         // Delete the top level
-        var deleteResult = await client.PostAsJsonAsync($"/api/posts/{postResult.Id}/delete", "");
+        var deleteResult = await client.DeleteAsync($"/api/posts/{postResult.Id}");
         deleteResult.EnsureSuccessStatusCode();
 
         // Query the posts
@@ -323,7 +323,7 @@ public class PostApiTests : IClassFixture<WebApplicationFactory<Program>>, IDisp
         {
             Content = "Post"
         };
-        var postResponse = await client.PutAsJsonAsync("/api/posts/create", postRequest);
+        var postResponse = await client.PutAsJsonAsync("/api/posts", postRequest);
         postResponse.EnsureSuccessStatusCode();
         var postResult = await postResponse.Content.ReadFromJsonAsync<CreatePostDTO>();
         var reply1Response = await client.PutAsJsonAsync($"api/posts/{postResult!.Id}/replies", postRequest);
@@ -334,7 +334,7 @@ public class PostApiTests : IClassFixture<WebApplicationFactory<Program>>, IDisp
         var reply2Result = await reply2Response.Content.ReadFromJsonAsync<CreatePostDTO>();
 
         // Delete the mid level
-        var deleteResult = await client.PostAsJsonAsync($"/api/posts/{reply1Result.Id}/delete", "");
+        var deleteResult = await client.DeleteAsync($"/api/posts/{reply1Result.Id}");
         deleteResult.EnsureSuccessStatusCode();
 
         // Query the posts
@@ -375,7 +375,7 @@ public class PostApiTests : IClassFixture<WebApplicationFactory<Program>>, IDisp
         {
             Content = "Hello world!"
         };
-        var makePostResponse = await client.PutAsJsonAsync("/api/posts/create", postRequest);
+        var makePostResponse = await client.PutAsJsonAsync("/api/posts", postRequest);
         makePostResponse.EnsureSuccessStatusCode();
         var makePostResult = await makePostResponse.Content.ReadFromJsonAsync<CreatePostDTO>();
         var postId = makePostResult!.Id;


### PR DESCRIPTION
This commit updates the user post API endpoints and accordingly adjusts the documentation and test suite. The endpoints now better follow REST conventions, for example `/api/posts/create` has changed to just `/api/posts` with a PUT request. This obviously introduces some breaking changes.