### PR TITLE
Implement petitions

### DIFF
--- a/backend/Api/Api.http
+++ b/backend/Api/Api.http
@@ -1,6 +1,0 @@
-@Api_HostAddress = http://localhost:5272
-
-GET {{Api_HostAddress}}/weatherforecast/
-Accept: application/json
-
-###

--- a/backend/Api/Controllers/PetitionsController.cs
+++ b/backend/Api/Controllers/PetitionsController.cs
@@ -1,0 +1,105 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using System.Security.Claims;
+using Api.Models;
+using Api.Services;
+using System.Numerics;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Api.ServiceUtils;
+using Microsoft.Extensions.Configuration.UserSecrets;
+
+namespace Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")] // base route: /api/example
+    public class PetitionsController : ControllerBase
+    {
+        private readonly PetitionsService _petitionsService;
+        public PetitionsController(PetitionsService petitionsService)
+        {
+            _petitionsService = petitionsService;
+        }
+
+
+        [HttpGet]
+        public async Task<IActionResult> GetPetitions(
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 10,
+            [FromQuery] string sortBy = "createdat",
+            [FromQuery] string sortOrder = "desc",
+            [FromQuery] int? userId = null,
+            [FromQuery] string? search = null
+        )
+        {
+            var (returnCode, posts) = await _petitionsService.GetPetitionsAsync(
+                page, pageSize,
+                sortBy, sortOrder,
+                userId,
+                search
+            );
+            var result = ServiceHelper.HandleReturnCode(returnCode);
+            if (result is not OkResult) { return result; }
+            return Ok(posts);
+        }
+
+        [HttpPut]
+        [Authorize]
+        public async Task<IActionResult> CreatePetition([FromBody] CreatePetitionDTO petition)
+        {
+            var userIdStr = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (userIdStr == null)
+            {
+                return Unauthorized();
+            }
+            int userId = int.Parse(userIdStr);
+
+            var (returnCode, createdPetition) = await _petitionsService.CreatePetitionAsync(userId, petition.Content);
+            var result = ServiceHelper.HandleReturnCode(returnCode);
+            if (result is not OkResult) { return result; }
+            return Ok(createdPetition);
+        }
+
+        [HttpDelete("{petitionId}")]
+        [Authorize]
+        public async Task<IActionResult> DeletePetition(int petitionId)
+        {
+            var userIdStr = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (userIdStr == null)
+            {
+                return Unauthorized();
+            }
+            int userId = int.Parse(userIdStr);
+
+            var (returnCode, deletedPetition) = await _petitionsService.DeletePetitionAsync(userId, petitionId);
+            var result = ServiceHelper.HandleReturnCode(returnCode);
+            if (result is not OkResult) { return result; }
+            return Ok(deletedPetition);
+        }
+
+        [HttpPut("{parentId}/replies")]
+        [Authorize]
+        public async Task<IActionResult> CreateReply(int parentId, [FromBody] CreatePetitionDTO petition)
+        {
+            var userIdStr = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (userIdStr == null)
+            {
+                return Unauthorized();
+            }
+            int userId = int.Parse(userIdStr);
+
+            var (returnCode, createdPost) = await _petitionsService.CreateReplyAsync(userId, parentId, petition.Content);
+            var result = ServiceHelper.HandleReturnCode(returnCode);
+            if (result is not OkResult) { return result; }
+            return Ok(createdPost);
+        }
+
+        [HttpGet("{parentId}/replies")]
+        public async Task<IActionResult> GetReplies(int parentId)
+        {
+            var (returnCode, replies) = await _petitionsService.GetRepliesAsync(parentId);
+            var result = ServiceHelper.HandleReturnCode(returnCode);
+            if (result is not OkResult) { return result; }
+            return Ok(replies);
+        }
+    }
+}

--- a/backend/Api/Models/PetitionDTO.cs
+++ b/backend/Api/Models/PetitionDTO.cs
@@ -1,0 +1,20 @@
+namespace Api.Models
+{
+    public class PetitionDTO
+    {
+        public int Id { get; set; }
+        public string? Content { get; set; }
+        public required DateTime CreatedAt { get; set; }
+        public required DateTime? UpdatedAt { get; set; }
+        public required string Author { get; set; }
+    }
+    public class CreatePetitionDTO
+    {
+        public int Id { get; set; }
+        public required string Content { get; set; }
+    }
+    public class DeletePetitionDTO
+    {
+        public int Id { get; set; }
+    }
+}

--- a/backend/Api/Program.cs
+++ b/backend/Api/Program.cs
@@ -57,6 +57,7 @@ builder.Services.AddAuthentication(options =>
 
 builder.Services.AddScoped<UserService>();
 builder.Services.AddScoped<PostsService>();
+builder.Services.AddScoped<PetitionsService>();
 builder.Services.AddScoped(sp =>
     sp.GetRequiredService<IOptions<JwtSettings>>().Value);
 builder.Services.AddScoped<JwtService>();

--- a/backend/Api/Services/PetitionsService.cs
+++ b/backend/Api/Services/PetitionsService.cs
@@ -1,0 +1,180 @@
+using Api.Data;
+using Api.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration.UserSecrets;
+using System.ComponentModel;
+using System.Linq.Dynamic.Core;
+using System.Reflection;
+using Api.ServiceUtils;
+using Npgsql;
+
+/*
+TODO:
+ESSENTIALS: GetAll (maybe not ALL) posts, GetAPost, GetPostsByUser, CreatePost, UpdatePost, DeletePost 
+EXTRA: ReactToPost, GetPostReactions, GetRepliesToAPost, CreateReplyToAPost, UpdateReplyToAPost, DeleteReplyToAPost
+*/
+namespace Api.Services
+{
+    public class PetitionsService
+    {
+        private readonly TVDbContext _context;
+
+        public PetitionsService(TVDbContext context)
+        {
+            _context = context;
+        }
+        public async Task<(ServiceReturnCode, PostQueryDTO?)> GetPetitionsAsync(
+            int page,
+            int pageSize,
+            string sortBy,
+            string sortOrder,
+            int? userId,
+            string? search
+        )
+        {
+            if (page <= 0 || pageSize <= 0) { return (ServiceReturnCode.InvalidInput, null); }
+            var sortProperty = typeof(Post).GetProperty(sortBy, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance); 
+            if (sortProperty == null) { return (ServiceReturnCode.InvalidInput, null); }
+
+            var query = _context.Petitions.AsQueryable();
+            if (userId.HasValue)
+            {
+                query = query.Where(p => p.UserId == userId);
+            }
+            if (search != null)
+            {
+                query = query.Where(p => p.Content.Contains(search));
+            }
+            query = sortOrder.ToLower() == "asc"
+                ? query.OrderBy(sortBy)
+                : query.OrderBy(sortBy + " descending");
+            query = query
+                .Where(p => !p.IsDeleted)
+                .Where(p => !p.IsOfficial)
+                .Where(p => p.ParentId == null);
+            var totalItems = await query.CountAsync();
+            var posts = await query
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .Include(p => p.Author)
+                .ToListAsync();
+            return (ServiceReturnCode.Success, new PostQueryDTO
+            {
+                TotalItems = totalItems,
+                Page = page,
+                PageSize = pageSize,
+                TotalPages = (int)Math.Ceiling(totalItems / (double)pageSize),
+                Posts = posts.Select(p => new PostDTO
+                {
+                    Id = p.Id,
+                    Content = p.Content,
+                    CreatedAt = p.CreatedAt,
+                    UpdatedAt = p.UpdatedAt,
+                    Author = p!.Author!.Username,
+                    Reactions = p.Reactions
+                }).ToList()
+            });
+        }
+        public async Task<(ServiceReturnCode, CreatePetitionDTO?)> CreatePetitionAsync(int userId, string content)
+        {
+            if (String.IsNullOrEmpty(content)) { return (ServiceReturnCode.InvalidInput,null); }
+            var petition = new Petition
+            {
+                UserId = userId,
+                Content = content
+            }; 
+            var createdPetition = await _context.AddAsync(petition);
+            if (createdPetition == null) { return (ServiceReturnCode.InternalError,null); }
+            await _context.SaveChangesAsync();
+            return (ServiceReturnCode.Success,new CreatePetitionDTO
+            {
+                Id = petition.Id,
+                Content = petition.Content,
+            });
+        }
+        public async Task<(ServiceReturnCode, DeletePetitionDTO?)> DeletePetitionAsync(int userId, int petitionId)
+        {
+            var petitionToDelete = await _context
+                .Petitions
+                .FirstOrDefaultAsync(p => p.Id == petitionId);
+            if (petitionToDelete == null) { return (ServiceReturnCode.NotFound, null); }
+            if (petitionToDelete.UserId != userId) { return (ServiceReturnCode.Unauthorized, null); }
+            if (petitionToDelete.IsDeleted) { return (ServiceReturnCode.NotFound, null); }
+            petitionToDelete.Status = PetitionStatus.Failed;
+            // TODO: Should deleted petitions be marked as deleted or kept visible but set as failed?
+            //       Waiting to hear back from the team. 
+            // petitionToDelete.IsDeleted = true;
+            petitionToDelete.UpdatedAt = DateTime.UtcNow;
+            // if (petitionToDelete.ParentId == null) // top level post, delete children
+            // {
+            //     await RecursivelyDeleteReplies(petitionToDelete.Id);
+            // }
+            await _context.SaveChangesAsync();
+            return (ServiceReturnCode.Success, new DeletePetitionDTO
+            {
+                Id = petitionToDelete.Id
+            });
+        }
+
+        public async Task<(ServiceReturnCode, CreatePostDTO?)> CreateReplyAsync(int userId, int parentId, string content)
+        {
+            if (String.IsNullOrEmpty(content)) { return (ServiceReturnCode.InvalidInput,null); }
+            var parent = await _context.Petitions.FirstOrDefaultAsync(p => p.Id == parentId);
+            if (parent == null || parent.IsDeleted)
+            {
+                return (ServiceReturnCode.NotFound, null);
+            }
+            var reply = new Post
+            {
+                UserId = userId,
+                ParentId = parentId, 
+                Content = content,
+                CreatedAt = DateTime.UtcNow,
+                ParentPost = parent
+            };
+            var createdReply = await _context.AddAsync(reply);
+            if (createdReply == null) { return (ServiceReturnCode.InternalError,null); }
+            await _context.SaveChangesAsync();
+            return (ServiceReturnCode.Success, new CreatePostDTO
+            {
+                Id = reply.Id,
+                Content = reply.Content
+            });
+        }
+        public async Task<(ServiceReturnCode, List<PostDTO>)> GetRepliesAsync(int parentId)
+        {
+            var replies = await _context.Posts
+                .Where(p => p.ParentId == parentId)
+                .Select(p => new PostDTO
+                {
+                    Id = p.Id,
+                    Content = p.IsDeleted ? null : p.Content,
+                    CreatedAt = p.CreatedAt,
+                    UpdatedAt = p.UpdatedAt,
+                    Author = p!.Author!.Username,
+                    Reactions = p.Reactions
+                }).ToListAsync();
+            return (ServiceReturnCode.Success, replies);
+        } 
+        // Helpers
+        private async Task<bool> RecursivelyDeleteReplies(int parentId)
+        {
+            await _context.Posts
+            .Where(p => p.ParentId == parentId)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(p => p.IsDeleted, true)
+                .SetProperty(p => p.UpdatedAt, DateTime.UtcNow)
+            );
+
+            var childIds = await _context.Posts
+                .Where(p => p.ParentId == parentId)
+                .Select(p => p.Id)
+                .ToListAsync();
+            foreach (var childId in childIds)
+            {
+                await RecursivelyDeleteReplies(childId);
+            }
+            return true;
+        }
+    }
+}

--- a/backend/Api/Services/PostsService.cs
+++ b/backend/Api/Services/PostsService.cs
@@ -51,7 +51,8 @@ namespace Api.Services
             query = query
                 .Where(p => !p.IsDeleted)
                 .Where(p => !p.IsOfficial)
-                .Where(p => p.ParentId == null);
+                .Where(p => p.ParentId == null)
+                .Where(po => !_context.Petitions.Any(pe => pe.Id == po.Id));
             var totalItems = await query.CountAsync();
             var posts = await query
                 .Skip((page - 1) * pageSize)

--- a/backend/Docs/API.md
+++ b/backend/Docs/API.md
@@ -268,3 +268,118 @@ Note that type is a stringly-typed enum, valid values are: `like`, `dislike`, `h
 }
 ```
 404 Not Found
+
+## Petitions
+### GET `/petitions`
+**Description:** Get a selection of petitions based on a query, optionally sorted.
+
+**Parameters:**
+|Name     |Type  |Required|Example    |Valid Values                                   |Default    |Description                                                                    |
+|:--------|:-----|:-------|:----------|:----------------------------------------------|:----------|:------------------------------------------------------------------------------|
+|page     |int   |true    |1          |page > 0                                       |1          |Group posts into groups of pageSize size and return the group with index `page`|
+|pageSize |int   |true    |10         |pageSize > 0                                   |10         |Determine the size of group for grouping posts into pages                      |
+|sortBy   |string|true    |"createdat"|"id","userid","content","createdat","updatedat"|"createdat"|Parameter to sort queried posts by                                             |
+|sortOrder|string|true    |"desc"     |"asc","desc"                                   |"desc"     |Order to sort posts in                                                         |
+|userId   |int   |false   |1          |userId >= 0                                    |null       |Optional parameter to limit posts to posts made by user with id `userid`       |
+|search   |string|false   |"findthis" |any string                                     |null       |Optional parameter to limit posts to posts containing the string `search`      |
+
+**Responses:**
+200 Ok
+```json
+{
+    "totalItems": 1,
+    "page": 1,
+    "pageSize": 10,
+    "totalPages": 1
+    "posts": [
+        {
+            "id": 1
+            "userId": 2,
+            "content": "Example post",
+            "createdAt": "2025-10-29T05:21:58.121288Z",
+            "updatedAt": null,
+            "reactions": [] 
+        }
+    ]
+}
+```
+400 Bad Request
+
+### PUT `/petitions`
+**Description:** Create a petition, requires a valid JWT.
+
+**Request Body (JSON):**
+```json
+{
+    "content": "This is an example petition!"
+}
+```
+
+**Responses:**
+200 Ok
+```json
+{
+    "id": 1,
+    "content": "This is an example petition!"
+}
+```
+400 BadRequest
+401 Unauthorized
+409 Conflict
+
+### DELETE `/petitions/{petitionId}`
+**Description:** Marks a petition as failed, requires a valid JWT and a valid target. 
+
+
+**Responses:**
+200 Ok
+```json
+{
+    "id": 1
+}
+```
+401 Unauthorized
+404 Not Found
+
+### PUT `/posts/{postId}/replies`
+**Description:** Create a reply to an existing post or reply, requires a valid JWT and a valid target.
+
+**Request Body (JSON):**
+```json
+{
+    "content": "This a reply to another post."
+}
+```
+
+**Responses:**
+200 Ok
+```json
+{
+    "id": 2,
+    "content": "This a reply to another post."
+}
+```
+401 Unauthorized
+404 Not Found
+
+### GET `/posts/{postId}/replies`
+**Description:** Get all replies to a given petition, requires a valid target. Deleted replies are also returned, but their contents are set to `null`.
+
+**Responses:**
+200 Ok
+```json
+{
+    [
+        {
+            "id": 2,
+            "content": "This a reply to a petition."
+        },
+        {
+            "id": 3,
+            "content": "This is also a reply to the same petition."
+        }
+    ]
+}
+```
+400 Bad Request
+404 Not Found

--- a/backend/Tests/PetitionTests.cs
+++ b/backend/Tests/PetitionTests.cs
@@ -1,0 +1,263 @@
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using Api.Services;
+using Api.Models;
+using Api.Controllers;
+using Api.Data;
+using System.Net.Http;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+[Collection("PostTests")]
+public class PetitionApiTests : IClassFixture<WebApplicationFactory<Program>>, IDisposable
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    public PetitionApiTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureLogging(logging =>
+            {
+                logging.ClearProviders();
+            });
+        });
+    }
+
+    private void ClearDatabase(TVDbContext dbContext)
+    {
+        dbContext.Users.RemoveRange(dbContext.Users);
+        dbContext.Posts.RemoveRange(dbContext.Posts);
+        dbContext.SaveChanges();
+    }
+
+    [Fact]
+    public async Task CreateDeletePetitionWithValidJWT_EndToEnd()
+    {
+        HttpClient client = _factory.CreateClient();
+        using var scope = _factory.Services.CreateScope();
+        TVDbContext dbContext = scope.ServiceProvider.GetRequiredService<TVDbContext>();
+        ClearDatabase(dbContext);
+        // Arrange
+        // Create user
+        string username = "john";
+        string name = "John Dingle";
+        string email = "test@tester.com";
+        string password = "P@ssw0rd!";
+        var createUserRequest = new CreateUserRequest { Username = username, Name = name, Email = email, Password = password };
+        var createUserResponse = await client.PutAsJsonAsync("/api/users/register", createUserRequest);
+        createUserResponse.EnsureSuccessStatusCode();
+
+        // Login and store JWT
+        var loginRequest = new UserLoginRequest { Username = username, Password = password };
+        var loginResponse = await client.PostAsJsonAsync("/api/users/login", loginRequest);
+        loginResponse.EnsureSuccessStatusCode();
+        var loginResult = await loginResponse.Content.ReadFromJsonAsync<UserLoginResponse>();
+        string jwt = loginResult!.Token;
+        client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwt);
+
+        // Test CRUD endpoints
+        var petitionRequest = new CreatePetitionDTO
+        {
+            Content = "Hello world!"
+        };
+        var makePetitionResponse = await client.PutAsJsonAsync("/api/petitions", petitionRequest);
+        makePetitionResponse.EnsureSuccessStatusCode();
+        var makePostResult = await makePetitionResponse.Content.ReadFromJsonAsync<CreatePetitionDTO>();
+        var postId = makePostResult!.Id;
+
+        var deletePetitionResponse = await client.DeleteAsync($"/api/petitions/{postId}");
+        deletePetitionResponse.EnsureSuccessStatusCode();
+
+        var petition = await dbContext.Petitions.FirstOrDefaultAsync(p => p.Id == postId);
+        Assert.Equal("Hello world!", petition!.Content);
+        Assert.NotNull(petition!.UpdatedAt);
+        Assert.Equal(PetitionStatus.Failed,petition!.Status);
+    }
+    [Fact]
+    public async Task CreatePetitionWithoutJWT_EndToEnd()
+    {
+        HttpClient client = _factory.CreateClient();
+        using var scope = _factory.Services.CreateScope();
+        TVDbContext dbContext = scope.ServiceProvider.GetRequiredService<TVDbContext>();
+        ClearDatabase(dbContext);
+
+        var petitionRequest = new CreatePetitionDTO
+        {
+            Content = "Hello world!"
+        };
+        var makePetitionResponse = await client.PutAsJsonAsync("/api/petitions", petitionRequest);
+        Assert.Equal(HttpStatusCode.Unauthorized, makePetitionResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteAnotherUserPetition_EndToEnd()
+    {
+
+        HttpClient client = _factory.CreateClient();
+        using var scope = _factory.Services.CreateScope();
+        TVDbContext dbContext = scope.ServiceProvider.GetRequiredService<TVDbContext>();
+        UserService userService = new UserService(dbContext);
+        PetitionsService petitionsService = new PetitionsService(dbContext);
+        ClearDatabase(dbContext);
+
+        // Create user
+        string username = "john";
+        string name = "John Dingle";
+        string email = "test@tester.com";
+        string password = "P@ssw0rd!";
+        var createUserRequest = new CreateUserRequest { Username = username, Name = name, Email = email, Password = password };
+        var createUserResponse = await client.PutAsJsonAsync("/api/users/register", createUserRequest);
+        createUserResponse.EnsureSuccessStatusCode();
+
+        // Login and store JWT
+        var loginRequest = new UserLoginRequest { Username = username, Password = password };
+        var loginResponse = await client.PostAsJsonAsync("/api/users/login", loginRequest);
+        loginResponse.EnsureSuccessStatusCode();
+        var loginResult = await loginResponse.Content.ReadFromJsonAsync<UserLoginResponse>();
+        string jwt = loginResult!.Token;
+        client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwt);
+
+        // Create a petition from another user
+        var newUser = await userService.RegisterUserAsync(new CreateUserRequest
+        {
+            Username = "tester2",
+            Name = "tester2",
+            Email = "tester@test.com",
+            Password = "P@ssw0rd!",
+        });
+        var (_, newPetition) = await petitionsService.CreatePetitionAsync(newUser!.Id, "Not Hello World!");
+        int petitionId = newPetition!.Id;
+
+        // Attempt to delete
+        var deletePostResponse = await client.DeleteAsync($"/api/posts/{petitionId}");
+        Assert.Equal(HttpStatusCode.Unauthorized, deletePostResponse.StatusCode);
+    }
+    [Fact]
+    public async Task CreateUpdateDeleteReplyWithValidJWT_EndToEnd()
+    {
+        HttpClient client = _factory.CreateClient();
+        using var scope = _factory.Services.CreateScope();
+        TVDbContext dbContext = scope.ServiceProvider.GetRequiredService<TVDbContext>();
+        ClearDatabase(dbContext);
+        // Arrange
+        // Create user
+        string username = "john";
+        string name = "John Dingle";
+        string email = "test@tester.com";
+        string password = "P@ssw0rd!";
+        var createUserRequest = new CreateUserRequest { Username = username, Name = name, Email = email, Password = password };
+        var createUserResponse = await client.PutAsJsonAsync("/api/users/register", createUserRequest);
+        createUserResponse.EnsureSuccessStatusCode();
+
+        // Login and store JWT
+        var loginRequest = new UserLoginRequest { Username = username, Password = password };
+        var loginResponse = await client.PostAsJsonAsync("/api/users/login", loginRequest);
+        loginResponse.EnsureSuccessStatusCode();
+        var loginResult = await loginResponse.Content.ReadFromJsonAsync<UserLoginResponse>();
+        string jwt = loginResult!.Token;
+        client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwt);
+
+        // Create petition
+        var petitionRequest = new CreatePetitionDTO
+        {
+            Content = "Hello world!"
+        };
+        var makePetitionResponse = await client.PutAsJsonAsync("/api/petitions", petitionRequest);
+        makePetitionResponse.EnsureSuccessStatusCode();
+        var makePostResult = await makePetitionResponse.Content.ReadFromJsonAsync<CreatePetitionDTO>();
+        var postId = makePostResult!.Id;
+        var replyRequest = new CreatePostDTO
+        {
+            Content = "I'm replying to a post!"
+        };
+        var makeReplyResponse = await client.PutAsJsonAsync($"/api/petitions/{postId}/replies", replyRequest);
+        var makeReplyResult = await makeReplyResponse.Content.ReadFromJsonAsync<CreatePostDTO>();
+        var replyId = makeReplyResult!.Id;
+
+        var updateReplyRequest = new UpdatePostDTO
+        {
+            NewContent = "Goodbye world!"
+        };
+        var updateReplyResponse = await client.PostAsJsonAsync($"/api/posts/{replyId}", updateReplyRequest);
+        updateReplyResponse.EnsureSuccessStatusCode();
+
+        var deleteReplyResponse = await client.DeleteAsync($"/api/posts/{replyId}");
+        deleteReplyResponse.EnsureSuccessStatusCode();
+
+        var post = await dbContext.Posts.FirstOrDefaultAsync(p => p.Id == replyId);
+        Assert.Equal("Goodbye world!", post!.Content);
+        Assert.NotNull(post!.UpdatedAt);
+        Assert.True(post!.IsDeleted);
+        Assert.Equal(postId, post!.ParentId);
+    }
+    [Fact]
+    public async Task CreateReplyWithoutJWT_EndToEnd()
+    {
+        HttpClient client = _factory.CreateClient();
+        using var scope = _factory.Services.CreateScope();
+        TVDbContext dbContext = scope.ServiceProvider.GetRequiredService<TVDbContext>();
+        UserService userService = new UserService(dbContext);
+        PetitionsService petitionsService = new PetitionsService(dbContext);
+        ClearDatabase(dbContext);
+
+        // Create a petition
+        var user = await userService.RegisterUserAsync(new CreateUserRequest
+        {
+            Username = "Test",
+            Name = "Test",
+            Password = "P@ssw0rd!",
+            Email = "test@test.com"
+        });
+        var (_,petition) = await petitionsService.CreatePetitionAsync(user!.Id, "Hello world!");
+
+        // Reply without JWT
+        var replyRequest = new CreatePostDTO
+        {
+            Content = "Hello world!"
+        };
+        var makeReplyResponse = await client.PutAsJsonAsync($"/api/petitions/{petition!.Id}/replies", replyRequest);
+        Assert.Equal(HttpStatusCode.Unauthorized, makeReplyResponse.StatusCode);
+    }
+    [Fact]
+    public async Task GetPetitionsDoesNotReturnPosts()
+    {
+        HttpClient client = _factory.CreateClient();
+        using var scope = _factory.Services.CreateScope();
+        TVDbContext dbContext = scope.ServiceProvider.GetRequiredService<TVDbContext>();
+        UserService userService = new UserService(dbContext);
+        PostsService postsService = new PostsService(dbContext);
+        PetitionsService petitionsService = new PetitionsService(dbContext);
+        ClearDatabase(dbContext);
+
+        // Create a post
+        var user = await userService.RegisterUserAsync(new CreateUserRequest
+        {
+            Username = "Test",
+            Name = "Test",
+            Password = "P@ssw0rd!",
+            Email = "test@test.com"
+        });
+        var (_,post) = await postsService.CreatePostAsync(user!.Id, "Hello world!");
+        // Create a petition
+        var (_,petition) = await petitionsService.CreatePetitionAsync(user!.Id, "Hello world petitioners!");
+        // Get petitions
+        var getPetitions = await client.GetAsync($"/api/petitions"); 
+        var petitions = await getPetitions.Content.ReadFromJsonAsync<PostQueryDTO>();
+        
+        Assert.Single(petitions!.Posts);
+        Assert.Equal("Hello world petitioners!",petitions!.Posts.First().Content);
+    }
+    public void Dispose()
+    {
+        using var scope = _factory.Services.CreateScope();
+        TVDbContext dbContext = scope.ServiceProvider.GetRequiredService<TVDbContext>();
+        ClearDatabase(dbContext);
+    }
+}


### PR DESCRIPTION
This commit implements petitions as a sub-type of post. Despite sharing a lot of overlap with posts, they have separate endpoints, and operations to each set of end points will generally only be able to interact with the associated type. Aside from adding petitions, documentation, and tests, this commit also makes minor adjustments to the behavior of posts to clearly delineate them from petitions.