### PR TITLE
Implement official posts

### DIFF
--- a/backend/Api/Controllers/PostsController.cs
+++ b/backend/Api/Controllers/PostsController.cs
@@ -35,7 +35,29 @@ namespace Api.Controllers
                 page, pageSize,
                 sortBy, sortOrder,
                 userId,
-                search
+                search,
+                false
+            );
+            var result = ServiceHelper.HandleReturnCode(returnCode);
+            if (result is not OkResult) { return result; }
+            return Ok(posts);
+        }
+        [HttpGet("official")]
+        public async Task<IActionResult> GetOfficialPosts(
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 10,
+            [FromQuery] string sortBy = "createdat",
+            [FromQuery] string sortOrder = "desc",
+            [FromQuery] int? userId = null,
+            [FromQuery] string? search = null
+        )
+        {
+            var (returnCode, posts) = await _postsService.GetPostsAsync(
+                page, pageSize,
+                sortBy, sortOrder,
+                userId,
+                search,
+                true
             );
             var result = ServiceHelper.HandleReturnCode(returnCode);
             if (result is not OkResult) { return result; }
@@ -54,6 +76,22 @@ namespace Api.Controllers
             int userId = int.Parse(userIdStr);
 
             var (returnCode, createdPost) = await _postsService.CreatePostAsync(userId, post.Content);
+            var result = ServiceHelper.HandleReturnCode(returnCode);
+            if (result is not OkResult) { return result; }
+            return Ok(createdPost);
+        }
+        [HttpPut("official")]
+        [Authorize]
+        public async Task<IActionResult> CreateOfficialPost([FromBody] CreatePostDTO post)
+        {
+            var userIdStr = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (userIdStr == null)
+            {
+                return Unauthorized();
+            }
+            int userId = int.Parse(userIdStr);
+
+            var (returnCode, createdPost) = await _postsService.CreateOfficialPostAsync(userId, post.Content);
             var result = ServiceHelper.HandleReturnCode(returnCode);
             if (result is not OkResult) { return result; }
             return Ok(createdPost);

--- a/backend/Api/Data/TVDbContext.cs
+++ b/backend/Api/Data/TVDbContext.cs
@@ -52,6 +52,9 @@ namespace Api.Data
             modelBuilder.Entity<User>()
                 .HasKey(u => u.Id);
             modelBuilder.Entity<User>()
+                .Property(u => u.IsOfficial)
+                .HasDefaultValue(false);
+            modelBuilder.Entity<User>()
                 .Property(u => u.CreatedAt)
                 .HasDefaultValueSql("CURRENT_TIMESTAMP");
         }

--- a/backend/Api/Migrations/20251114092247_UserOfficialFlag.Designer.cs
+++ b/backend/Api/Migrations/20251114092247_UserOfficialFlag.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Api.Migrations
 {
     [DbContext(typeof(TVDbContext))]
-    partial class TVDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251114092247_UserOfficialFlag")]
+    partial class UserOfficialFlag
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -176,12 +179,6 @@ namespace Api.Migrations
                     b.Property<int>("PetitionId")
                         .HasColumnType("integer")
                         .HasColumnName("petitionid");
-
-                    b.Property<DateTime>("CreatedAt")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("createdat")
-                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
 
                     b.HasKey("UserId", "PetitionId");
 

--- a/backend/Api/Migrations/20251114092247_UserOfficialFlag.cs
+++ b/backend/Api/Migrations/20251114092247_UserOfficialFlag.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class UserOfficialFlag : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "isofficial",
+                table: "users",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "isofficial",
+                table: "users");
+        }
+    }
+}

--- a/backend/Api/Models/DatabaseModels.cs
+++ b/backend/Api/Models/DatabaseModels.cs
@@ -7,7 +7,8 @@ namespace Api.Models
         public int Id { get; set; }
         public required string Username { get; set; }
         public required string Email { get; set; }
-        public DateTime CreatedAt { get; set; }
+        public bool IsOfficial { get; set; } // default value `false` enforced at database level 
+        public DateTime CreatedAt { get; set; } // defualt value `CURRENT_TIMESTAMP` enforced at database level
 
         public required UserAuth Auth { get; set; }
         public required UserProfile Profile { get; set; }

--- a/backend/Docs/API.md
+++ b/backend/Docs/API.md
@@ -268,6 +268,66 @@ Note that type is a stringly-typed enum, valid values are: `like`, `dislike`, `h
 }
 ```
 404 Not Found
+## Official Posts
+Official posts are just a special type of post, most of their operations use the default post routes. The only different routes are shown below:
+
+### GET `/posts/official`
+**Description:** Get a selection of official posts based on a query, optionally sorted.
+
+**Parameters:**
+|Name     |Type  |Required|Example    |Valid Values                                   |Default    |Description                                                                    |
+|:--------|:-----|:-------|:----------|:----------------------------------------------|:----------|:------------------------------------------------------------------------------|
+|page     |int   |true    |1          |page > 0                                       |1          |Group posts into groups of pageSize size and return the group with index `page`|
+|pageSize |int   |true    |10         |pageSize > 0                                   |10         |Determine the size of group for grouping posts into pages                      |
+|sortBy   |string|true    |"createdat"|"id","userid","content","createdat","updatedat"|"createdat"|Parameter to sort queried posts by                                             |
+|sortOrder|string|true    |"desc"     |"asc","desc"                                   |"desc"     |Order to sort posts in                                                         |
+|userId   |int   |false   |1          |userId >= 0                                    |null       |Optional parameter to limit posts to posts made by user with id `userid`       |
+|search   |string|false   |"findthis" |any string                                     |null       |Optional parameter to limit posts to posts containing the string `search`      |
+
+**Responses:**
+200 Ok
+```json
+{
+    "totalItems": 1,
+    "page": 1,
+    "pageSize": 10,
+    "totalPages": 1
+    "posts": [
+        {
+            "id": 1
+            "userId": 2,
+            "content": "Example post",
+            "createdAt": "2025-10-29T05:21:58.121288Z",
+            "updatedAt": null,
+            "reactions": [] 
+        }
+    ]
+}
+```
+400 Bad Request
+
+### PUT `/posts/official`
+**Description:** Create an official post, requires a valid JWT and that the user account backed by the JWT is an official user.
+
+**Request Body (JSON):**
+```json
+{
+    "content": "This is an example post!"
+}
+```
+
+**Responses:**
+200 Ok
+```json
+{
+    "id": 1,
+    "content": "This is an example post!"
+}
+```
+400 BadRequest
+401 Unauthorized
+409 Conflict
+
 
 ## Petitions
 ### GET `/petitions`


### PR DESCRIPTION
This commit adds official posts along with their documentation, tests, etc. This feature was relatively easy to implement as a special type of posts. Most API routes for official posts use standard post API routes, except for creation and querying.